### PR TITLE
Fixing build script so 'latest' tag points to => 'team' edition

### DIFF
--- a/scripts/build-editions.sh
+++ b/scripts/build-editions.sh
@@ -15,11 +15,11 @@ MINOR="${VERSIONARRAY[1]}"
 HUBREPO="mijime/mattermost"
 
 for edition in team enterprise; do
+
     docker build \
     --build-arg MATTERMOST_VER=${MATTERMOST_VER} \
     --build-arg MATTERMOST_EDITION=${edition} \
     -f Dockerfile \
-    -t "${HUBREPO}":latest \
     -t "${HUBREPO}":"${MATTERMOST_VER}"-${edition} \
     -t "${HUBREPO}":"${MAJOR}"."${MINOR}"-${edition} \
     -t "${HUBREPO}":"${MAJOR}"-${edition} .
@@ -30,8 +30,15 @@ for edition in team enterprise; do
 
     # Team Edition will have the 'latest' tag
     if [[ "${edition}" == "team" ]]; then
-        docker build -f Dockerfile -t "${HUBREPO}":latest .
+
+        docker build \
+        --build-arg MATTERMOST_VER=${MATTERMOST_VER} \
+        --build-arg MATTERMOST_EDITION=${edition} \
+        -f Dockerfile \
+        -t "${HUBREPO}":latest .
+
         docker push "${HUBREPO}":latest
+
     fi
 
 done

--- a/scripts/build-editions.sh
+++ b/scripts/build-editions.sh
@@ -19,10 +19,10 @@ for edition in team enterprise; do
     docker build \
     --build-arg MATTERMOST_VER=${MATTERMOST_VER} \
     --build-arg MATTERMOST_EDITION=${edition} \
-    -f Dockerfile \
-    -t "${HUBREPO}":"${MATTERMOST_VER}"-${edition} \
-    -t "${HUBREPO}":"${MAJOR}"."${MINOR}"-${edition} \
-    -t "${HUBREPO}":"${MAJOR}"-${edition} .
+    --file Dockerfile \
+    --tag "${HUBREPO}":"${MATTERMOST_VER}"-${edition} \
+    --tag "${HUBREPO}":"${MAJOR}"."${MINOR}"-${edition} \
+    --tag "${HUBREPO}":"${MAJOR}"-${edition} .
 
     for pushstring in "${MATTERMOST_VER}-${edition}" "${MAJOR}.${MINOR}-${edition}" "${MAJOR}-${edition}"; do
         docker push "${HUBREPO}:${pushstring}"
@@ -34,8 +34,8 @@ for edition in team enterprise; do
         docker build \
         --build-arg MATTERMOST_VER=${MATTERMOST_VER} \
         --build-arg MATTERMOST_EDITION=${edition} \
-        -f Dockerfile \
-        -t "${HUBREPO}":latest .
+        --file Dockerfile \
+        --tag "${HUBREPO}":latest .
 
         docker push "${HUBREPO}":latest
 


### PR DESCRIPTION
# What

Fixing the `scripts/build-edition.sh` script so that the `latest` tag points to `team` version of Mattermost since that's what most people will be using.

# Why
If you notice in my comment here (https://github.com/mijime/docker-mattermost/pull/23#issuecomment-298804797) the list of `mijime/mattermost` images that I built as a test on local were as follows:

```
mijime/mattermost   3-enterprise        6c81297b09b4
mijime/mattermost   3.8-enterprise      6c81297b09b4
mijime/mattermost   3.8.2-enterprise    6c81297b09b4
mijime/mattermost   latest              6c81297b09b4
mijime/mattermost   3-team              87961639cef1
mijime/mattermost   3.8-team            87961639cef1
mijime/mattermost   3.8.2-team          87961639cef1
```

The `latest` tag points to the Enterprise build of Mattermost, which in my opinion is **_not correct_** since most users will be running the `team` version. This PR fixes that so the following images will be generated:

```
REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
mijime/mattermost   3-enterprise        f7796cf7faf7        5 minutes ago       103 MB
mijime/mattermost   3.8-enterprise      f7796cf7faf7        5 minutes ago       103 MB
mijime/mattermost   3.8.2-enterprise    f7796cf7faf7        5 minutes ago       103 MB
mijime/mattermost   3-team              27207e93ee25        5 minutes ago       101 MB
mijime/mattermost   3.8-team            27207e93ee25        5 minutes ago       101 MB
mijime/mattermost   3.8.2-team          27207e93ee25        5 minutes ago       101 MB
mijime/mattermost   latest              27207e93ee25        5 minutes ago       101 MB
```

Which shows that `latest` correctly points to the `team` version of Mattermost.

# Misc
@mijime Once this PR is merged, can you please run `make build` so that the Docker Hub images are updated with the following naming conventions?

```
${MAJOR}.${MINOR}.${RELEASE}-${FLAVOR}
${MAJOR}.${MINOR}-${FLAVOR}
${MAJOR}-${FLAVOR}
```